### PR TITLE
Fix boost placeholders

### DIFF
--- a/src/device.h
+++ b/src/device.h
@@ -468,7 +468,7 @@ struct Port_device: public Context_device<ContextProvider> {
               size_t len_offset_1 = (*data)[0] + response_found;
               size_t len_offset_2  = (data->size() > 1) ? (*data)[1] + response_found: -1;
               expected_len = response.size() > len_offset_1 ? response[len_offset_1] : 0;
-              expected_len += len_offset_2 >= 0 && response.size() > len_offset_2 ?
+              expected_len += response.size() > len_offset_2 ?
                 response[len_offset_2] << 8: 0;
               // Add length of item upto lenght indicator for total length
               expected_len += static_cast<uint16_t>(std::max(len_offset_1, len_offset_2)) + 1;

--- a/test/test_asio.cpp
+++ b/test/test_asio.cpp
@@ -3,8 +3,9 @@
 #include <boost/test/unit_test.hpp>
 
 #include <boost/chrono.hpp>
-#include <boost/thread/thread.hpp> 
+#include <boost/thread/thread.hpp>
 
+#include <boost/bind/bind.hpp>
 #include <boost/asio.hpp>
 #include <boost/asio/spawn.hpp>
 #include <boost/thread.hpp>
@@ -14,7 +15,7 @@
 #include <string>
 
 namespace asio = boost::asio;
-
+using namespace boost::placeholders;
 
 BOOST_AUTO_TEST_CASE(buffer_test) {
   asio::streambuf b;

--- a/test/test_device.cpp
+++ b/test/test_device.cpp
@@ -1,6 +1,6 @@
 #define BOOST_TEST_MODULE log_test
 #include <boost/date_time/posix_time/posix_time.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 #include "../src/device.h" 
 #include "../src/usb.h"
@@ -31,6 +31,7 @@ struct Some_device: public Device {
 };
 
 using My_device = Some_device<Port>;
+using namespace boost::placeholders;
 
 
 BOOST_AUTO_TEST_CASE(container_test) {

--- a/test/test_fusion.cpp
+++ b/test/test_fusion.cpp
@@ -1,6 +1,6 @@
 #define BOOST_TEST_MODULE fusion_test
 #include <boost/date_time/posix_time/posix_time.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 #include "../src/processor.h" 
 #include "../src/processors/fusion.h" 
@@ -16,6 +16,7 @@
 #include "test_common.h"
 
 namespace posix_time = boost::posix_time;
+using namespace boost::placeholders;
 
 
 

--- a/test/test_modbus.cpp
+++ b/test/test_modbus.cpp
@@ -1,6 +1,6 @@
 #define BOOST_TEST_MODULE modbus_test
 #include <boost/test/unit_test.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/asio.hpp>
 #include <boost/property_tree/ptree.hpp>
 
@@ -11,6 +11,7 @@
 
 namespace asio = boost::asio;
 namespace prtr = boost::property_tree;
+using namespace boost::placeholders;
 
 
 static int result1 = 0;

--- a/test/test_processor.cpp
+++ b/test/test_processor.cpp
@@ -1,6 +1,6 @@
 #define BOOST_TEST_MODULE log_test
 #include <boost/date_time/posix_time/posix_time.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 #include "../src/processor.h" 
 #include "../src/processors/statistics.h" 
@@ -18,7 +18,7 @@
 #include "test_common.h"
 
 namespace posix_time = boost::posix_time;
-
+using namespace boost::placeholders;
 
 BOOST_AUTO_TEST_CASE(statistics_test, * ut::tolerance(0.00000001)) {
   Statistics stats;

--- a/test/test_signalk.cpp
+++ b/test/test_signalk.cpp
@@ -1,6 +1,6 @@
 #define BOOST_TEST_MODULE fusion_test
 #include <boost/date_time/posix_time/posix_time.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 #include "../src/processor.h" 
 #include "../src/processors/signalk.h" 
@@ -16,6 +16,7 @@
 #include "test_common.h"
 
 namespace posix_time = boost::posix_time;
+using namespace boost::placeholders;
 
 
 

--- a/test/test_usb.cpp
+++ b/test/test_usb.cpp
@@ -7,9 +7,10 @@
  */
 #define BOOST_TEST_MODULE usb_test
 #define BOOST_COROUTINES_NO_DEPRECATION_WARNING 1
+
 #include <boost/asio.hpp>
 #include <boost/asio/spawn.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <iostream>
 #include <istream>
 #include <exception>
@@ -29,6 +30,7 @@ typedef const bytes_t cbytes_t;
 
 
 namespace asio = boost::asio;
+using namespace boost::placeholders;
 
 
 static bool read_returned = false;


### PR DESCRIPTION
tests now compile without warnings on both boost 1.71 and 1.73